### PR TITLE
19 418 dropping call - tests

### DIFF
--- a/src/UE/Tests/Application/Mocks/IBtsPortMock.hpp
+++ b/src/UE/Tests/Application/Mocks/IBtsPortMock.hpp
@@ -30,6 +30,7 @@ public:
     MOCK_METHOD(void, sendSms, (common::PhoneNumber, std::string), (override));
     MOCK_METHOD(void, sendCallRequest, (common::PhoneNumber), (override));
     MOCK_METHOD(void, sendCallAccept, (common::PhoneNumber), (override));
+    MOCK_METHOD(void, sendCallDropped, (common::PhoneNumber), (override));  
 };
 
 }

--- a/src/UE/Tests/Application/TestSuites/ApplicationCallDropTestSuite.cpp
+++ b/src/UE/Tests/Application/TestSuites/ApplicationCallDropTestSuite.cpp
@@ -1,0 +1,96 @@
+#include "ApplicationCallDropTestSuite.hpp"
+#include <gtest/gtest.h>
+#include <chrono>
+using namespace std::chrono_literals;
+
+class MockCallManager {
+public:
+    MOCK_METHOD(void, dropCall, (int callId), ());
+    MOCK_METHOD(bool, isCallActive, (int callId), ());
+};
+
+TEST(ApplicationCallDropTestSuite, DropCallSuccessfully) {
+    MockCallManager mockCallManager;
+    int callId = 1;
+
+    EXPECT_CALL(mockCallManager, isCallActive(callId))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(mockCallManager, dropCall(callId))
+        .Times(1);
+
+    if (mockCallManager.isCallActive(callId)) {
+        mockCallManager.dropCall(callId);
+    }
+}
+
+TEST(ApplicationCallDropTestSuite, DropCallWhenNotActive) {
+    MockCallManager mockCallManager;
+    int callId = 2;
+
+    EXPECT_CALL(mockCallManager, isCallActive(callId))
+        .WillOnce(::testing::Return(false));
+    EXPECT_CALL(mockCallManager, dropCall(callId))
+        .Times(0);
+
+    if (!mockCallManager.isCallActive(callId)) {
+        mockCallManager.dropCall(callId);
+    }
+}
+
+namespace ue
+{
+    void ApplicationCallDropTestSuite::setupConnectedAndInCallMode(const common::PhoneNumber& phoneNumber)
+    {
+        EXPECT_CALL(userPortMock, showNotConnected());
+        EXPECT_CALL(btsPortMock, sendAttachRequest(BTS_ID));
+        EXPECT_CALL(timerPortMock, startTimer(500ms));
+        EXPECT_CALL(userPortMock, showConnecting());
+        objectUnderTest.handleSib(BTS_ID);
+        
+        EXPECT_CALL(timerPortMock, stopTimer());
+        EXPECT_CALL(userPortMock, showConnected());
+        objectUnderTest.handleAttachAccept();
+        
+        EXPECT_CALL(userPortMock, showCallRequest(phoneNumber));
+        objectUnderTest.handleCallReceive(common::MessageId::CallTalk, phoneNumber);
+    }
+
+    TEST_F(ApplicationCallDropTestSuite, shallSendCallDroppedWhenUserHangsUp)
+    {
+        common::PhoneNumber phoneNumber{123};
+        setupConnectedAndInCallMode(phoneNumber);
+        
+        std::function<void()> acceptCallback;
+        EXPECT_CALL(userPortMock, acceptCallback(_))
+            .WillOnce(testing::SaveArg<0>(&acceptCallback));
+
+        std::function<void()> rejectCallback;
+        EXPECT_CALL(userPortMock, rejectCallback(_))
+            .WillOnce(testing::SaveArg<0>(&rejectCallback));
+            
+        EXPECT_CALL(btsPortMock, sendCallAccept(phoneNumber));
+        if (acceptCallback) acceptCallback();
+        
+        EXPECT_CALL(btsPortMock, sendCallDropped(phoneNumber));
+        EXPECT_CALL(userPortMock, showConnected());
+        
+        if (rejectCallback) rejectCallback();
+    }
+    
+    TEST_F(ApplicationCallDropTestSuite, shallShowConnectedWhenPeerDropsCall)
+    {
+        common::PhoneNumber phoneNumber{123};
+        setupConnectedAndInCallMode(phoneNumber);
+        
+        std::function<void()> acceptCallback;
+        EXPECT_CALL(userPortMock, acceptCallback(_))
+            .WillOnce(testing::SaveArg<0>(&acceptCallback));
+            
+        EXPECT_CALL(btsPortMock, sendCallAccept(phoneNumber));
+        if (acceptCallback) acceptCallback();
+        
+        EXPECT_CALL(userPortMock, showConnected());
+        
+        objectUnderTest.handleCallMessage(common::MessageId::CallDropped, phoneNumber);
+    }
+}

--- a/src/UE/Tests/Application/TestSuites/ApplicationCallDropTestSuite.hpp
+++ b/src/UE/Tests/Application/TestSuites/ApplicationCallDropTestSuite.hpp
@@ -1,0 +1,16 @@
+#ifndef APPLICATION_CALL_DROP_TEST_SUITE_HPP
+#define APPLICATION_CALL_DROP_TEST_SUITE_HPP
+
+#include "ApplicationTestSuite.hpp"
+
+namespace ue
+{
+
+struct ApplicationCallDropTestSuite : ApplicationTestSuite
+{
+    void setupConnectedAndInCallMode(const common::PhoneNumber& phoneNumber);
+};
+
+}
+
+#endif


### PR DESCRIPTION
Tests were made for CURRENT version of calls, so they might need refactor in the future. They check if the phone states matches those we want. Also fixes  cmake --build . --target all by adding mock method for call dropped in IBtsPortMock