### PR TITLE
3 414 viewing sms

### DIFF
--- a/src/UE/Application/Application.cpp
+++ b/src/UE/Application/Application.cpp
@@ -1,5 +1,6 @@
 #include "Application.hpp"
 #include "Sms/Sms.hpp"
+#include "States/ViewSmsListState.hpp"
 
 namespace ue
 {
@@ -69,7 +70,13 @@ void Application::handleSmsReceived(common::PhoneNumber from, const std::string&
     Sms newSms = Sms(text, from, context.phoneNumber, std::chrono::system_clock::now());
     context.messages.push_back(newSms);
     context.hasUnreadMessages = true;
-    
+
+    context.state->handleSmsReceived(from, text);
+
+    if (dynamic_cast<ViewSmsListState*>(context.state.get()) == nullptr) {
+        context.user.showNewSmsIndicator(true);
+    }
+
     // More advanced log for debug purposes
     logger.logInfo("Current SMS database contains ", context.messages.size(), " messages:");
     for (size_t i = 0; i < context.messages.size(); ++i) {
@@ -77,8 +84,7 @@ void Application::handleSmsReceived(common::PhoneNumber from, const std::string&
         std::string status = sms.hasBeenRead() ? "read" : "unread";
         logger.logInfo("  [", i+1, "] From: ", sms.getFrom(), " | Status: ", status, " | Text: ", sms.getText());
     }
-    
-    context.state->handleSmsReceived(from, text);
+
 }
 
 Context& Application::getContext() {

--- a/src/UE/Application/Application.cpp
+++ b/src/UE/Application/Application.cpp
@@ -65,8 +65,7 @@ void Application::handleCallReceive(common::MessageId msgId, common::PhoneNumber
 
 void Application::handleSmsReceived(common::PhoneNumber from, const std::string& text)
 {
-    logger.logInfo("SMS received from ", from);
-    
+
     Sms newSms = Sms(text, from, context.phoneNumber, std::chrono::system_clock::now());
     context.messages.push_back(newSms);
     context.hasUnreadMessages = true;
@@ -75,14 +74,6 @@ void Application::handleSmsReceived(common::PhoneNumber from, const std::string&
 
     if (dynamic_cast<ViewSmsListState*>(context.state.get()) == nullptr) {
         context.user.showNewSmsIndicator(true);
-    }
-
-    // More advanced log for debug purposes
-    logger.logInfo("Current SMS database contains ", context.messages.size(), " messages:");
-    for (size_t i = 0; i < context.messages.size(); ++i) {
-        const auto& sms = context.messages[i];
-        std::string status = sms.hasBeenRead() ? "read" : "unread";
-        logger.logInfo("  [", i+1, "] From: ", sms.getFrom(), " | Status: ", status, " | Text: ", sms.getText());
     }
 
 }

--- a/src/UE/Application/Ports/BtsPort.cpp
+++ b/src/UE/Application/Ports/BtsPort.cpp
@@ -61,7 +61,6 @@ void BtsPort::handleMessage(BinaryMessage msg)
             case common::MessageId::Sms:
             {
                 std::string text = reader.readRemainingText();
-                logger.logInfo("Received SMS from ", from, ": ", text);
                 handler->handleSmsReceived(from, text);
                 break;
             }

--- a/src/UE/Application/Ports/IUserPort.hpp
+++ b/src/UE/Application/Ports/IUserPort.hpp
@@ -29,7 +29,7 @@ public:
     virtual void doubleClickCallback(IUeGui::Callback doubleClickCallback) = 0;
     virtual void homeCallback(IUeGui::Callback homeCallback) = 0;
     virtual int getScreenId() = 0;
-    
+
     virtual IUeGui::ISmsComposeMode &activateComposeMode() = 0;
     virtual IUeGui::IDialMode &activateDialMode() = 0;
 
@@ -37,6 +37,7 @@ public:
     virtual void showEmptySmsListView() = 0;
     virtual void showSmsView(const std::string& text) = 0;
     virtual void smsSelectedCallback(std::function<void(size_t)> callback) = 0;
+    virtual void showNewSmsIndicator(bool hasNew) = 0;
 };
 
 }

--- a/src/UE/Application/Ports/IUserPort.hpp
+++ b/src/UE/Application/Ports/IUserPort.hpp
@@ -32,6 +32,11 @@ public:
     
     virtual IUeGui::ISmsComposeMode &activateComposeMode() = 0;
     virtual IUeGui::IDialMode &activateDialMode() = 0;
+
+    virtual void showSmsListView(const std::vector<std::string>& smsInfoItems) = 0;
+    virtual void showEmptySmsListView() = 0;
+    virtual void showSmsView(const std::string& from, const std::string& text) = 0;
+    virtual void smsSelectedCallback(std::function<void(size_t)> callback) = 0;
 };
 
 }

--- a/src/UE/Application/Ports/IUserPort.hpp
+++ b/src/UE/Application/Ports/IUserPort.hpp
@@ -35,7 +35,7 @@ public:
 
     virtual void showSmsListView(const std::vector<std::string>& smsInfoItems) = 0;
     virtual void showEmptySmsListView() = 0;
-    virtual void showSmsView(const std::string& from, const std::string& text) = 0;
+    virtual void showSmsView(const std::string& text) = 0;
     virtual void smsSelectedCallback(std::function<void(size_t)> callback) = 0;
 };
 

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -148,11 +148,10 @@ void UserPort::showEmptySmsListView()
     listView.addSelectionListItem("No messages", "");
 }
 
-void UserPort::showSmsView(const std::string& from, const std::string& text)
+void UserPort::showSmsView(const std::string& text)
 {
-    auto &textMode = gui.setViewTextMode();
-    textMode.setText("From: " + from);
-    textMode.setText(text);
+    auto &mode = gui.setViewTextMode();
+    mode.setText(text);
 }
 
 void UserPort::smsSelectedCallback(std::function<void(size_t)> callback)

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -157,8 +157,9 @@ void UserPort::showSmsView(const std::string& from, const std::string& text)
 
 void UserPort::smsSelectedCallback(std::function<void(size_t)> callback)
 {
-    gui.setAcceptCallback([this, callback]() {
-        auto sel = gui.setListViewMode().getCurrentItemIndex();
+    gui.setDoubleClickCallback([this, callback]() {
+        auto &list = gui.setListViewMode();
+        auto sel = list.getCurrentItemIndex();
         if (sel.first) callback(sel.second);
     });
 }

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -132,6 +132,36 @@ IUeGui::IDialMode &UserPort::activateDialMode() {
     return mode;
 }
 
+void UserPort::showSmsListView(const std::vector<std::string>& smsInfoItems)
+{
+    auto &listView = gui.setListViewMode();
+    listView.clearSelectionList();
+    for (const auto& info : smsInfoItems) {
+        listView.addSelectionListItem(info, "");
+    }
+}
+
+void UserPort::showEmptySmsListView()
+{
+    auto &listView = gui.setListViewMode();
+    listView.clearSelectionList();
+    listView.addSelectionListItem("No messages", "");
+}
+
+void UserPort::showSmsView(const std::string& from, const std::string& text)
+{
+    auto &textMode = gui.setViewTextMode();
+    textMode.setText("From: " + from);
+    textMode.setText(text);
+}
+
+void UserPort::smsSelectedCallback(std::function<void(size_t)> callback)
+{
+    gui.setAcceptCallback([this, callback]() {
+        auto sel = gui.setListViewMode().getCurrentItemIndex();
+        if (sel.first) callback(sel.second);
+    });
+}
 
 
 }

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -163,5 +163,9 @@ void UserPort::smsSelectedCallback(std::function<void(size_t)> callback)
     });
 }
 
+    void UserPort::showNewSmsIndicator(bool hasNew)
+{
+    gui.showNewSms(hasNew);
+}
 
 }

--- a/src/UE/Application/Ports/UserPort.hpp
+++ b/src/UE/Application/Ports/UserPort.hpp
@@ -38,7 +38,7 @@ public:
 
     void showSmsListView(const std::vector<std::string>& smsInfoItems) override;
     void showEmptySmsListView() override;
-    void showSmsView(const std::string& from, const std::string& text) override;
+    void showSmsView(const std::string& text) override;
     void smsSelectedCallback(std::function<void(size_t)> callback) override;
 
 private:

--- a/src/UE/Application/Ports/UserPort.hpp
+++ b/src/UE/Application/Ports/UserPort.hpp
@@ -40,6 +40,7 @@ public:
     void showEmptySmsListView() override;
     void showSmsView(const std::string& text) override;
     void smsSelectedCallback(std::function<void(size_t)> callback) override;
+    void showNewSmsIndicator(bool hasNew) override;
 
 private:
     common::PrefixedLogger logger;

--- a/src/UE/Application/Ports/UserPort.hpp
+++ b/src/UE/Application/Ports/UserPort.hpp
@@ -36,6 +36,10 @@ public:
     virtual IUeGui::ISmsComposeMode &activateComposeMode() override;
     virtual IUeGui::IDialMode &activateDialMode() override;
 
+    void showSmsListView(const std::vector<std::string>& smsInfoItems) override;
+    void showEmptySmsListView() override;
+    void showSmsView(const std::string& from, const std::string& text) override;
+    void smsSelectedCallback(std::function<void(size_t)> callback) override;
 
 private:
     common::PrefixedLogger logger;

--- a/src/UE/Application/Sms/SmsFormatter.hpp
+++ b/src/UE/Application/Sms/SmsFormatter.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Sms/Sms.hpp"
+#include "Messages/PhoneNumber.hpp"
+#include <string>
+
+namespace ue {
+
+    /// Formats a single SMS for the list: “[status] To:/From: <number>”
+    inline std::string formatSmsLabel(const Sms& sms, const common::PhoneNumber& me) {
+        std::string status = sms.hasBeenRead() ? "read" : "NEW";
+        bool outgoing = (sms.getFrom() == me);
+        common::PhoneNumber other = outgoing ? sms.getTo() : sms.getFrom();
+        std::string prefix = outgoing ? "To: " : "From: ";
+        return "[" + status + "] " + prefix + std::to_string(other.value);
+    }
+
+}

--- a/src/UE/Application/States/ComposeSmsState.cpp
+++ b/src/UE/Application/States/ComposeSmsState.cpp
@@ -22,14 +22,6 @@ namespace ue {
         sentSms.markAsRead(); // since we are sending it
         context.messages.push_back(sentSms);
         
-        // More advanced log for debug purposes
-        logger.logInfo("Current SMS database contains ", context.messages.size(), " messages:");
-        for (size_t i = 0; i < context.messages.size(); ++i) {
-            const auto& sms = context.messages[i];
-            std::string status = sms.hasBeenRead() ? "read" : "unread";
-            logger.logInfo("  [", i+1, "] From: ", sms.getFrom(), " | Status: ", status, " | Text: ", sms.getText());
-        }
-        
         context.setState<ConnectedState>();
     }
 

--- a/src/UE/Application/States/ConnectedState.cpp
+++ b/src/UE/Application/States/ConnectedState.cpp
@@ -5,6 +5,7 @@
 #include "ComposeSmsState.hpp"
 #include "DialState.hpp"
 #include "TalkingState.hpp"
+#include "ViewSmsListState.hpp"
 
 namespace ue
 {
@@ -24,7 +25,7 @@ ConnectedState::ConnectedState(Context &context)
                 context.setState<ComposeSmsState>();
                 break;
             case VIEW_SMS_SCREEN:
-                logger.logInfo("Screen not implemented.");
+                context.setState<ViewSmsListState>();
                 break;
             case MAKE_CALL_SCREEN:
                 context.setState<DialState>();

--- a/src/UE/Application/States/ViewSmsListState.cpp
+++ b/src/UE/Application/States/ViewSmsListState.cpp
@@ -1,28 +1,40 @@
 #include "ViewSmsListState.hpp"
 #include "ViewSmsState.hpp"
+#include "Sms/SmsFormatter.hpp"
 
 namespace ue {
 
     ViewSmsListState::ViewSmsListState(Context& context)
         : ConnectedState(context)
     {
-        logger.logInfo("Entering ViewSmsList state");
+        refreshList();
+        context.user.smsSelectedCallback([this](std::size_t idx){ handleSmsSelected(idx); });
+        context.user.rejectCallback([this](){ closeView(); });
+    }
+
+    void ViewSmsListState::handleSmsReceived(common::PhoneNumber /*from*/, const std::string& /*text*/)
+    {
+        refreshList();
+    }
+
+    void ViewSmsListState::refreshList()
+    {
         if (context.messages.empty()) {
             context.user.showEmptySmsListView();
         } else {
             std::vector<std::string> items;
-            for (size_t i = 0; i < context.messages.size(); ++i) {
-                const auto& sms = context.messages[i];
-                std::string status = sms.hasBeenRead() ? "read" : "NEW";
-                items.push_back("[" + status + "] From: " + std::to_string(sms.getFrom().value));
+            items.reserve(context.messages.size());
+
+            for (const Sms& sms : context.messages) {
+                items.push_back(formatSmsLabel(sms, context.phoneNumber));
             }
+
             context.user.showSmsListView(items);
         }
-        context.user.smsSelectedCallback([this](size_t idx){ handleSmsSelected(idx); });
-        context.user.rejectCallback([this](){ closeView(); });
     }
 
-    void ViewSmsListState::handleSmsSelected(std::size_t index) {
+    void ViewSmsListState::handleSmsSelected(std::size_t index)
+    {
         if (index < context.messages.size()) {
             context.setState<ViewSmsState>(index);
         } else {
@@ -30,7 +42,8 @@ namespace ue {
         }
     }
 
-    void ViewSmsListState::closeView() {
+    void ViewSmsListState::closeView()
+    {
         context.setState<ConnectedState>();
     }
 

--- a/src/UE/Application/States/ViewSmsListState.cpp
+++ b/src/UE/Application/States/ViewSmsListState.cpp
@@ -1,0 +1,37 @@
+#include "ViewSmsListState.hpp"
+#include "ViewSmsState.hpp"
+
+namespace ue {
+
+    ViewSmsListState::ViewSmsListState(Context& context)
+        : ConnectedState(context)
+    {
+        logger.logInfo("Entering ViewSmsList state");
+        if (context.messages.empty()) {
+            context.user.showEmptySmsListView();
+        } else {
+            std::vector<std::string> items;
+            for (size_t i = 0; i < context.messages.size(); ++i) {
+                const auto& sms = context.messages[i];
+                std::string status = sms.hasBeenRead() ? "read" : "NEW";
+                items.push_back("[" + status + "] From: " + std::to_string(sms.getFrom().value));
+            }
+            context.user.showSmsListView(items);
+        }
+        context.user.smsSelectedCallback([this](size_t idx){ handleSmsSelected(idx); });
+        context.user.rejectCallback([this](){ closeView(); });
+    }
+
+    void ViewSmsListState::handleSmsSelected(std::size_t index) {
+        if (index < context.messages.size()) {
+            context.setState<ViewSmsState>(index);
+        } else {
+            logger.logError("Invalid SMS index: ", index);
+        }
+    }
+
+    void ViewSmsListState::closeView() {
+        context.setState<ConnectedState>();
+    }
+
+}

--- a/src/UE/Application/States/ViewSmsListState.cpp
+++ b/src/UE/Application/States/ViewSmsListState.cpp
@@ -7,6 +7,7 @@ namespace ue {
     ViewSmsListState::ViewSmsListState(Context& context)
         : ConnectedState(context)
     {
+      	context.user.showNewSmsIndicator(false);
         refreshList();
         context.user.smsSelectedCallback([this](std::size_t idx){ handleSmsSelected(idx); });
         context.user.rejectCallback([this](){ closeView(); });

--- a/src/UE/Application/States/ViewSmsListState.hpp
+++ b/src/UE/Application/States/ViewSmsListState.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ConnectedState.hpp"
+
+namespace ue {
+
+class ViewSmsListState : public ConnectedState {
+public:
+    ViewSmsListState(Context& context);
+    ~ViewSmsListState() override = default;
+
+    std::string getName() const override { return "ViewSmsListState"; }
+
+private:
+    void handleSmsSelected(std::size_t index);
+    void closeView();
+};
+
+}

--- a/src/UE/Application/States/ViewSmsListState.hpp
+++ b/src/UE/Application/States/ViewSmsListState.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ConnectedState.hpp"
+#include <string>
 
 namespace ue {
 
@@ -11,9 +12,11 @@ public:
 
     std::string getName() const override { return "ViewSmsListState"; }
 
+    void handleSmsReceived(common::PhoneNumber from, const std::string& text) override;
 private:
     void handleSmsSelected(std::size_t index);
     void closeView();
+    void refreshList();
 };
 
 }

--- a/src/UE/Application/States/ViewSmsState.cpp
+++ b/src/UE/Application/States/ViewSmsState.cpp
@@ -1,24 +1,25 @@
 #include "ViewSmsState.hpp"
 #include "ViewSmsListState.hpp"
+#include "Sms/SmsFormatter.hpp"
 
 namespace ue {
 
 ViewSmsState::ViewSmsState(Context& context, std::size_t smsIndex)
     : ConnectedState(context), smsIndex(smsIndex)
 {
-    logger.logInfo("Entering ViewSmsState, SMS #", smsIndex+1);
     if (smsIndex < context.messages.size()) {
-        auto& sms = context.messages[smsIndex];
+        Sms& sms = context.messages[smsIndex];
+
         if (!sms.hasBeenRead()) {
             sms.markAsRead();
-
             bool anyNew = false;
-            for (auto &m : context.messages) {
+            for (const Sms& m : context.messages) {
                 if (!m.hasBeenRead()) { anyNew = true; break; }
             }
             context.hasUnreadMessages = anyNew;
         }
-        context.user.showSmsView(std::to_string(sms.getFrom().value), sms.getText());
+
+        context.user.showSmsView(sms.getText());
         context.user.rejectCallback([this](){ closeView(); });
     } else {
         logger.logError("Invalid SMS index: ", smsIndex);
@@ -26,7 +27,8 @@ ViewSmsState::ViewSmsState(Context& context, std::size_t smsIndex)
     }
 }
 
-void ViewSmsState::closeView() {
+void ViewSmsState::closeView()
+{
     context.setState<ViewSmsListState>();
 }
 

--- a/src/UE/Application/States/ViewSmsState.cpp
+++ b/src/UE/Application/States/ViewSmsState.cpp
@@ -1,0 +1,33 @@
+#include "ViewSmsState.hpp"
+#include "ViewSmsListState.hpp"
+
+namespace ue {
+
+ViewSmsState::ViewSmsState(Context& context, std::size_t smsIndex)
+    : ConnectedState(context), smsIndex(smsIndex)
+{
+    logger.logInfo("Entering ViewSmsState, SMS #", smsIndex+1);
+    if (smsIndex < context.messages.size()) {
+        auto& sms = context.messages[smsIndex];
+        if (!sms.hasBeenRead()) {
+            sms.markAsRead();
+
+            bool anyNew = false;
+            for (auto &m : context.messages) {
+                if (!m.hasBeenRead()) { anyNew = true; break; }
+            }
+            context.hasUnreadMessages = anyNew;
+        }
+        context.user.showSmsView(std::to_string(sms.getFrom().value), sms.getText());
+        context.user.rejectCallback([this](){ closeView(); });
+    } else {
+        logger.logError("Invalid SMS index: ", smsIndex);
+        context.setState<ViewSmsListState>();
+    }
+}
+
+void ViewSmsState::closeView() {
+    context.setState<ViewSmsListState>();
+}
+
+}

--- a/src/UE/Application/States/ViewSmsState.hpp
+++ b/src/UE/Application/States/ViewSmsState.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ConnectedState.hpp"
+
+namespace ue {
+
+    class ViewSmsState : public ConnectedState {
+    public:
+        ViewSmsState(Context& context, std::size_t smsIndex);
+        ~ViewSmsState() override = default;
+
+        std::string getName() const override { return "ViewSmsState"; }
+    private:
+        std::size_t smsIndex;
+        void closeView();
+    };
+
+}


### PR DESCRIPTION
Implement SMS viewing and streamline SMS logging:

- Live-refresh list when new messages arrive
- Label outgoing SMS as “To:” and incoming as “From:”
- Remove redundant debug logging in SMS handling
- Add global new-SMS indicator, cleared on entering list view

Closes #3 