### PR TITLE
8 419 call talking

### DIFF
--- a/src/UE/Application/Application.cpp
+++ b/src/UE/Application/Application.cpp
@@ -63,6 +63,11 @@ void Application::handleCallReceive(common::MessageId msgId, common::PhoneNumber
     context.state->handleCallReceive(msgId, from);
 }
 
+void Application::handleCallTalk(common::PhoneNumber from, const std::string& text)
+{
+    context.state->handleCallTalk(from, text);
+}
+
 void Application::handleSmsReceived(common::PhoneNumber from, const std::string& text)
 {
 

--- a/src/UE/Application/Application.hpp
+++ b/src/UE/Application/Application.hpp
@@ -33,6 +33,7 @@ public:
     void handleDisconnect() override;
     void handleCallMessage(common::MessageId msgId, common::PhoneNumber from) override;
     void handleCallReceive(common::MessageId msgId, common::PhoneNumber from) override;
+    void handleCallTalk(common::PhoneNumber from, const std::string& text) override;
     void handleSmsReceived(common::PhoneNumber from, const std::string& text) override;
 
     Context& getContext();

--- a/src/UE/Application/Ports/BtsPort.cpp
+++ b/src/UE/Application/Ports/BtsPort.cpp
@@ -53,6 +53,7 @@ void BtsPort::handleMessage(BinaryMessage msg)
             }
             case common::MessageId::UnknownRecipient:
             case common::MessageId::CallRequest:
+            case common::MessageId::CallAccepted:
             case common::MessageId::CallDropped:
             {
                 handler->handleCallMessage(msgId, from);

--- a/src/UE/Application/Ports/BtsPort.cpp
+++ b/src/UE/Application/Ports/BtsPort.cpp
@@ -59,6 +59,12 @@ void BtsPort::handleMessage(BinaryMessage msg)
                 handler->handleCallMessage(msgId, from);
                 break;
             }
+            case common::MessageId::CallTalk:
+            {
+            	std::string talk = reader.readRemainingText();
+                handler->handleCallTalk(from, talk);
+                break;
+            }
             case common::MessageId::Sms:
             {
                 std::string text = reader.readRemainingText();
@@ -115,4 +121,12 @@ void BtsPort::sendCallDropped(common::PhoneNumber to)
     common::OutgoingMessage outgoingMessage(common::MessageId::CallDropped, phoneNumber, to);
     transport.sendMessage(outgoingMessage.getMessage());
 }
+
+void BtsPort::sendCallTalk(common::PhoneNumber to, const std::string& text)
+{
+    common::OutgoingMessage outgoingMessage(common::MessageId::CallTalk, phoneNumber, to);
+    outgoingMessage.writeText(text);
+    transport.sendMessage(outgoingMessage.getMessage());
+}
+
 }

--- a/src/UE/Application/Ports/BtsPort.hpp
+++ b/src/UE/Application/Ports/BtsPort.hpp
@@ -20,6 +20,7 @@ public:
     void sendCallRequest(common::PhoneNumber) override;
     void sendCallAccept(common::PhoneNumber) override;
     void sendCallDropped(common::PhoneNumber to) override;
+    void sendCallTalk(common::PhoneNumber to, const std::string& text) override;
 
 private:
     void handleMessage(BinaryMessage msg);

--- a/src/UE/Application/Ports/IBtsPort.hpp
+++ b/src/UE/Application/Ports/IBtsPort.hpp
@@ -18,6 +18,7 @@ public:
     virtual void handleDisconnect() = 0;
     virtual void handleCallMessage(common::MessageId msgId, common::PhoneNumber from) = 0;
     virtual void handleCallReceive(common::MessageId msgId, common::PhoneNumber from) = 0;
+    virtual void handleCallTalk(common::PhoneNumber from, const std::string& text) = 0;
     virtual void handleSmsReceived(common::PhoneNumber from, const std::string& text) = 0;
 };
 
@@ -31,6 +32,7 @@ public:
     virtual void sendCallRequest(common::PhoneNumber) = 0;
     virtual void sendCallAccept(common::PhoneNumber) = 0;
     virtual void sendCallDropped(common::PhoneNumber to) = 0;
+    virtual void sendCallTalk(common::PhoneNumber to, const std::string& text) = 0;
 };
 
 }

--- a/src/UE/Application/Ports/IUserPort.hpp
+++ b/src/UE/Application/Ports/IUserPort.hpp
@@ -32,6 +32,7 @@ public:
 
     virtual IUeGui::ISmsComposeMode &activateComposeMode() = 0;
     virtual IUeGui::IDialMode &activateDialMode() = 0;
+    virtual IUeGui::ICallMode &activateCallMode() = 0;
 
     virtual void showSmsListView(const std::vector<std::string>& smsInfoItems) = 0;
     virtual void showEmptySmsListView() = 0;

--- a/src/UE/Application/Ports/IUserPort.hpp
+++ b/src/UE/Application/Ports/IUserPort.hpp
@@ -39,6 +39,7 @@ public:
     virtual void showSmsView(const std::string& text) = 0;
     virtual void smsSelectedCallback(std::function<void(size_t)> callback) = 0;
     virtual void showNewSmsIndicator(bool hasNew) = 0;
+    virtual void setCloseGuard(IUeGui::CloseGuard guard) = 0;
 };
 
 }

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -169,9 +169,13 @@ void UserPort::smsSelectedCallback(std::function<void(size_t)> callback)
     });
 }
 
-    void UserPort::showNewSmsIndicator(bool hasNew)
+void UserPort::showNewSmsIndicator(bool hasNew)
 {
     gui.showNewSms(hasNew);
 }
 
+void UserPort::setCloseGuard(IUeGui::CloseGuard guard)
+{
+    gui.setCloseGuard(guard);
+}
 }

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -132,6 +132,12 @@ IUeGui::IDialMode &UserPort::activateDialMode() {
     return mode;
 }
 
+IUeGui::ICallMode &UserPort::activateCallMode() {
+    IUeGui::ICallMode &mode = gui.setCallMode();
+
+    return mode;
+}
+
 void UserPort::showSmsListView(const std::vector<std::string>& smsInfoItems)
 {
     auto &listView = gui.setListViewMode();

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -68,7 +68,7 @@ void UserPort::showCallDropped()
     alertMode.setText("Call dropped.");
 
     const auto handler = [&] {
-        gui.setListViewMode();
+        showConnected();
     };
 
     gui.setAcceptCallback(handler);
@@ -82,7 +82,7 @@ void UserPort::showCallTimeout()
     alertMode.setText("Call timeout.");
 
     const auto handler = [&] {
-        gui.setListViewMode();
+        gui.showConnected();
     };
 
     gui.setAcceptCallback(handler);

--- a/src/UE/Application/Ports/UserPort.hpp
+++ b/src/UE/Application/Ports/UserPort.hpp
@@ -42,6 +42,7 @@ public:
     void showSmsView(const std::string& text) override;
     void smsSelectedCallback(std::function<void(size_t)> callback) override;
     void showNewSmsIndicator(bool hasNew) override;
+    virtual void setCloseGuard(IUeGui::CloseGuard guard) override;
 
 private:
     common::PrefixedLogger logger;

--- a/src/UE/Application/Ports/UserPort.hpp
+++ b/src/UE/Application/Ports/UserPort.hpp
@@ -35,6 +35,7 @@ public:
 
     virtual IUeGui::ISmsComposeMode &activateComposeMode() override;
     virtual IUeGui::IDialMode &activateDialMode() override;
+    virtual IUeGui::ICallMode &activateCallMode() override;
 
     void showSmsListView(const std::vector<std::string>& smsInfoItems) override;
     void showEmptySmsListView() override;

--- a/src/UE/Application/States/BaseState.cpp
+++ b/src/UE/Application/States/BaseState.cpp
@@ -54,6 +54,11 @@ namespace ue
         logger.logError("BaseState: handling receving call.");
     }
 
+    void BaseState::handleCallTalk(common::PhoneNumber from, const std::string& text)
+    {
+        logger.logError("BaseState: unexpected CallTalk from ", to_string(from));
+    }
+
     void BaseState::handleSmsReceived(common::PhoneNumber from, const std::string& text)
     {
         logger.logInfo("SMS saved from ", from, " with text: ", text);

--- a/src/UE/Application/States/BaseState.hpp
+++ b/src/UE/Application/States/BaseState.hpp
@@ -26,6 +26,7 @@ public:
     void handleDisconnect() override;
     void handleCallMessage(common::MessageId msgId, common::PhoneNumber from) override;
     void handleCallReceive(common::MessageId msgId, common::PhoneNumber from) override;
+    void handleCallTalk(common::PhoneNumber from, const std::string& text) override;
     void handleSmsReceived(common::PhoneNumber from, const std::string& text) override;
 
 protected:

--- a/src/UE/Application/States/ConnectedState.cpp
+++ b/src/UE/Application/States/ConnectedState.cpp
@@ -56,6 +56,9 @@ void ConnectedState::handleCallMessage(common::MessageId msgId, common::PhoneNum
             context.bts.sendCallDropped(from);
             context.setState<ConnectedState>();
         });
+    } else if (msgId == common::MessageId::CallAccepted) {
+      	logger.logInfo("Call accepted from ", to_string(from));
+      	context.setState<TalkingState>();
     }
 }
 

--- a/src/UE/Application/States/DialState.cpp
+++ b/src/UE/Application/States/DialState.cpp
@@ -21,6 +21,8 @@ namespace ue {
     }
 
     void DialState::handleCallMessage(common::MessageId msgId, common::PhoneNumber from) {
+        context.peerPhoneNumber = from;
+
         switch (msgId) {
             case common::MessageId::CallAccepted:
                 context.timer.stopTimer();

--- a/src/UE/Application/States/DialState.cpp
+++ b/src/UE/Application/States/DialState.cpp
@@ -10,16 +10,6 @@ namespace ue {
 
     DialState::DialState(Context &context) : ConnectedState(context), iDialMode(context.user.activateDialMode())
     {
-        // This code sets phrase "Incoming text" in text box instead of old call talk history
-        // TODO: If this would generate problems (ie. in tests), just delete it
-        auto &callMode = dynamic_cast<IUeGui::ICallMode&>(context.user.activateCallMode());
-        callMode.clearIncomingText();
-        callMode.clearOutgoingText();
-        callMode.appendIncomingText("Incoming text");
-
-        // back to dial mode
-        context.user.activateDialMode();
-
         context.user.homeCallback([this]{ this->context.user.showConnected(); });
         context.user.acceptCallback([this]{ sendCallRequest(); });
     }

--- a/src/UE/Application/States/DialState.cpp
+++ b/src/UE/Application/States/DialState.cpp
@@ -1,5 +1,6 @@
 #include "DialState.hpp"
 #include "TalkingState.hpp"
+#include "UeGui/ICallMode.hpp"
 
 using namespace std::chrono_literals;
 
@@ -9,6 +10,16 @@ namespace ue {
 
     DialState::DialState(Context &context) : ConnectedState(context), iDialMode(context.user.activateDialMode())
     {
+        // This code sets phrase "Incoming text" in text box instead of old call talk history
+        // TODO: If this would generate problems (ie. in tests), just delete it
+        auto &callMode = dynamic_cast<IUeGui::ICallMode&>(context.user.activateCallMode());
+        callMode.clearIncomingText();
+        callMode.clearOutgoingText();
+        callMode.appendIncomingText("Incoming text");
+
+        // back to dial mode
+        context.user.activateDialMode();
+
         context.user.homeCallback([this]{ this->context.user.showConnected(); });
         context.user.acceptCallback([this]{ sendCallRequest(); });
     }

--- a/src/UE/Application/States/TalkingState.cpp
+++ b/src/UE/Application/States/TalkingState.cpp
@@ -3,11 +3,13 @@
 namespace ue {
     std::string TalkingState::getName() const { return "TalkingState"; }
 
-    TalkingState::TalkingState(Context &context) : ConnectedState(context) {
+    TalkingState::TalkingState(Context &context) : ConnectedState(context), iCallMode(context.user.activateCallMode()) {
         logger.logInfo("[TalkingState] Talking state constructor.");
+
 
         context.user.rejectCallback([this, &context] {
             logger.logInfo("[TalkingState] User hung up the call.");
+            logger.logInfo("[TalkingState] Sending call dropped to peer: ", to_string(context.peerPhoneNumber));
             context.bts.sendCallDropped(context.peerPhoneNumber);
             context.user.showConnected();
             context.setState<ConnectedState>();
@@ -17,6 +19,7 @@ namespace ue {
 
     void TalkingState::handleCallMessage(common::MessageId msgId, common::PhoneNumber from)
     {
+    logger.logInfo("Message received: ", to_string(msgId));
     if (msgId == common::MessageId::CallDropped)
     {
         logger.logInfo("Call dropped by peer: ", to_string(from));

--- a/src/UE/Application/States/TalkingState.cpp
+++ b/src/UE/Application/States/TalkingState.cpp
@@ -5,7 +5,6 @@ namespace ue {
     std::string TalkingState::getName() const { return "TalkingState"; }
 
     TalkingState::TalkingState(Context &context) : ConnectedState(context), iCallMode(context.user.activateCallMode()) {
-        logger.logInfo("[TalkingState] Talking state constructor.");
 
         iCallMode.clearIncomingText();
         iCallMode.clearOutgoingText();
@@ -26,12 +25,15 @@ namespace ue {
             context.setState<ConnectedState>();
             iCallMode.clearIncomingText();
         });
-        
+
+        context.user.setCloseGuard([this]() -> bool {
+            this->context.bts.sendCallDropped(this->context.peerPhoneNumber);
+            return true;
+        });
     }
 
     void TalkingState::handleCallMessage(common::MessageId msgId, common::PhoneNumber from)
     {
-    logger.logInfo("Message received: ", to_string(msgId));
     if (msgId == common::MessageId::CallDropped)
     {
         logger.logInfo("Call dropped by peer: ", to_string(from));

--- a/src/UE/Application/States/TalkingState.cpp
+++ b/src/UE/Application/States/TalkingState.cpp
@@ -38,6 +38,6 @@ namespace ue {
 
     void TalkingState::handleCallTalk(common::PhoneNumber from, const std::string& text)
     {
-        iCallMode.appendIncomingText("[Peer]: " + text);
+        iCallMode.appendIncomingText("[" + to_string(from) + "]: " + text);
     }
 }

--- a/src/UE/Application/States/TalkingState.cpp
+++ b/src/UE/Application/States/TalkingState.cpp
@@ -7,6 +7,9 @@ namespace ue {
     TalkingState::TalkingState(Context &context) : ConnectedState(context), iCallMode(context.user.activateCallMode()) {
         logger.logInfo("[TalkingState] Talking state constructor.");
 
+        iCallMode.clearIncomingText();
+        iCallMode.clearOutgoingText();
+
         context.user.acceptCallback([this, &context] {
             std::string text = iCallMode.getOutgoingText();
             if (text.empty()) return;
@@ -21,6 +24,7 @@ namespace ue {
             context.bts.sendCallDropped(context.peerPhoneNumber);
             context.user.showConnected();
             context.setState<ConnectedState>();
+            iCallMode.clearIncomingText();
         });
         
     }

--- a/src/UE/Application/States/TalkingState.cpp
+++ b/src/UE/Application/States/TalkingState.cpp
@@ -37,6 +37,13 @@ namespace ue {
         logger.logInfo("Call dropped by peer: ", to_string(from));
         context.setState<ConnectedState>();
         context.user.showCallDropped();
+    } else if (msgId == common::MessageId::CallRequest)
+    {
+        if (from != context.peerPhoneNumber)
+        {
+            logger.logInfo("Busy: dropping new call request from ", to_string(from));
+            context.bts.sendCallDropped(from);
+        }
     }
     }
 

--- a/src/UE/Application/States/TalkingState.cpp
+++ b/src/UE/Application/States/TalkingState.cpp
@@ -35,8 +35,8 @@ namespace ue {
     if (msgId == common::MessageId::CallDropped)
     {
         logger.logInfo("Call dropped by peer: ", to_string(from));
-        context.user.showConnected();
         context.setState<ConnectedState>();
+        context.user.showCallDropped();
     }
     }
 

--- a/src/UE/Application/States/TalkingState.hpp
+++ b/src/UE/Application/States/TalkingState.hpp
@@ -9,6 +9,7 @@ namespace ue
         public:
             TalkingState(Context& context);
             void handleCallMessage(common::MessageId msgId, common::PhoneNumber from) override;
+            void handleCallTalk(common::PhoneNumber from, const std::string& text) override;
             std::string getName() const override;
         private:
             IUeGui::ICallMode& iCallMode;

--- a/src/UE/Application/States/TalkingState.hpp
+++ b/src/UE/Application/States/TalkingState.hpp
@@ -10,5 +10,7 @@ namespace ue
             TalkingState(Context& context);
             void handleCallMessage(common::MessageId msgId, common::PhoneNumber from) override;
             std::string getName() const override;
+        private:
+            IUeGui::ICallMode& iCallMode;
     };
 }


### PR DESCRIPTION
Implement call (talking) handling:

- Implement send/receive `CallTalk` functionality and propagate it across states (`BaseState`, `TalkingState`).
- Enhance text handling in `Dial` and `Talking` states.
- Address issues with `CallDropped` alerts, ensuring correct display and GUI responsiveness.
- Add proper handling for edge cases like UE closing and `CallRequest` during an ongoing call.
- Display the sender's phone number in incoming texts during active calls.

Closes #8 