### PR TITLE
fix: clear reject callback on ConnectedState

### DIFF
--- a/src/UE/Application/States/ConnectedState.cpp
+++ b/src/UE/Application/States/ConnectedState.cpp
@@ -17,6 +17,8 @@ ConnectedState::ConnectedState(Context &context)
 {
     context.user.doubleClickCallback([this] { changeScreen();});
     context.user.showConnected();
+    context.user.rejectCallback([this] {
+    });
 }
 
     void ConnectedState::changeScreen() {

--- a/src/UE/Application/States/TalkingState.cpp
+++ b/src/UE/Application/States/TalkingState.cpp
@@ -22,8 +22,8 @@ namespace ue {
             logger.logInfo("[TalkingState] Sending call dropped to peer: ", to_string(context.peerPhoneNumber));
             context.bts.sendCallDropped(context.peerPhoneNumber);
             context.user.showConnected();
-            context.setState<ConnectedState>();
             iCallMode.clearIncomingText();
+            context.setState<ConnectedState>();
         });
 
         context.user.setCloseGuard([this]() -> bool {


### PR DESCRIPTION
One fix was applied, due to reject callback registration on talking state, when clicking it again it was trying to use object which was out out context (destructed) which made seg fault and killed app. This change should solve it